### PR TITLE
Renderer improvements: PCG3D RNG, SAH BVH, energy-conserving path tracing

### DIFF
--- a/src/bin/live_raytracer.rs
+++ b/src/bin/live_raytracer.rs
@@ -40,6 +40,7 @@ struct SceneObject {
     color: [f32; 3],
     roughness: f32,
     metallic: f32,
+    glass: bool,
     enabled: bool,
 }
 
@@ -1299,6 +1300,7 @@ impl State {
                     color: [1.0, 1.0, 1.0],
                     roughness: 0.25,
                     metallic: 0.0, // Diffuse ground
+                    glass: false,
                     enabled: true,
                 },
                 SceneObject {
@@ -1308,15 +1310,17 @@ impl State {
                     color: [0.8, 1.0, 0.8],
                     roughness: 0.1,
                     metallic: 1.0, // Shiny metal
+                    glass: false,
                     enabled: true,
                 },
                 SceneObject {
-                    name: "Blue Diffuse Sphere".to_string(),
+                    name: "Glass Sphere".to_string(),
                     position: [-1.6, 0.0, 5.0],
                     radius: 1.0,
-                    color: [0.0, 0.0, 1.0],
-                    roughness: 0.5,
-                    metallic: 0.0, // Diffuse
+                    color: [1.0, 1.0, 1.0], // Clear glass (white = untinted)
+                    roughness: 0.0,
+                    metallic: 0.0,
+                    glass: true,
                     enabled: true,
                 },
             ],
@@ -1726,7 +1730,14 @@ impl State {
             .iter()
             .filter(|obj| obj.enabled)
             .map(|obj| {
-                let material_type = if obj.metallic > 0.5 { 1.0 } else { 0.0 }; // 0.0 = diffuse, 1.0 = metallic
+                // 0.0 = diffuse, 1.0 = metallic, 2.0 = dielectric (glass)
+                let material_type = if obj.glass {
+                    2.0
+                } else if obj.metallic > 0.5 {
+                    1.0
+                } else {
+                    0.0
+                };
                 GpuSphere {
                     center_radius: [
                         obj.position[0],
@@ -2100,6 +2111,12 @@ impl State {
                                                     needs_update = true;
                                                 }
                                             });
+                                            if ui
+                                                .checkbox(&mut obj.glass, "Glass (refractive)")
+                                                .changed()
+                                            {
+                                                needs_update = true;
+                                            }
                                             if ui.color_edit_button_rgb(&mut obj.color).changed() {
                                                 needs_update = true;
                                             }
@@ -2161,6 +2178,7 @@ impl State {
                                     color: ui_state.new_object_color,
                                     roughness: 0.5,
                                     metallic: 0.0,
+                                    glass: false,
                                     enabled: true,
                                 });
                                 ui_state.show_add_object_dialog = false;

--- a/src/bin/live_raytracer.rs
+++ b/src/bin/live_raytracer.rs
@@ -648,13 +648,13 @@ impl State {
             1.0,
             Material::new_metallic(Vec3::new(0.8, 1.0, 0.8), 0.1), // Light green, low roughness = very shiny
         );
-        // Blue diffuse sphere for comparison
+        // Clear glass sphere (refractive) - matches the UI scene default
         let sphere3 = Sphere::new(
             Vec3::new(-1.6, 0.0, 5.0),
             1.0,
-            Material::new(Vec3::new(0.0, 0.0, 1.0), 0.5),
+            Material::new_dielectric(Vec3::new(1.0, 1.0, 1.0), 0.0),
         );
-        eprintln!("Green sphere at (2.0, 0.0, 5.0), Blue sphere at (-1.6, 0.0, 5.0)");
+        eprintln!("Green sphere at (2.0, 0.0, 5.0), Glass sphere at (-1.6, 0.0, 5.0)");
         let spheres = [sphere1, sphere2, sphere3];
 
         let (triangles, mut bvh_nodes) = mesh_to_gpu_data(&bunny);

--- a/src/gpu_scene.rs
+++ b/src/gpu_scene.rs
@@ -91,6 +91,93 @@ fn centroid_component(primitive: &TrianglePrimitive, axis: usize) -> f64 {
     }
 }
 
+fn axis_value(vec: Vec3, axis: usize) -> f64 {
+    match axis {
+        0 => vec.x,
+        1 => vec.y,
+        _ => vec.z,
+    }
+}
+
+fn surface_area(min: Vec3, max: Vec3) -> f64 {
+    let dx = (max.x - min.x).max(0.0);
+    let dy = (max.y - min.y).max(0.0);
+    let dz = (max.z - min.z).max(0.0);
+    2.0 * (dx * dy + dy * dz + dz * dx)
+}
+
+/// A bucket used by the binned Surface Area Heuristic builder.
+#[derive(Clone, Copy)]
+struct SahBin {
+    count: usize,
+    bounds_min: Vec3,
+    bounds_max: Vec3,
+}
+
+impl SahBin {
+    fn empty() -> Self {
+        SahBin {
+            count: 0,
+            bounds_min: Vec3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY),
+            bounds_max: Vec3::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY),
+        }
+    }
+
+    fn expand(&mut self, min: Vec3, max: Vec3) {
+        self.bounds_min.x = self.bounds_min.x.min(min.x);
+        self.bounds_min.y = self.bounds_min.y.min(min.y);
+        self.bounds_min.z = self.bounds_min.z.min(min.z);
+        self.bounds_max.x = self.bounds_max.x.max(max.x);
+        self.bounds_max.y = self.bounds_max.y.max(max.y);
+        self.bounds_max.z = self.bounds_max.z.max(max.z);
+    }
+
+    fn merge(&mut self, other: &SahBin) {
+        self.count += other.count;
+        if other.count > 0 {
+            self.expand(other.bounds_min, other.bounds_max);
+        }
+    }
+
+    fn area(&self) -> f64 {
+        if self.count == 0 {
+            0.0
+        } else {
+            surface_area(self.bounds_min, self.bounds_max)
+        }
+    }
+}
+
+/// Reorder `indices` so that primitives whose centroid is below `split` along
+/// `axis` come first. Returns the number of primitives on the left side.
+fn partition_indices(
+    indices: &mut [usize],
+    primitives: &[TrianglePrimitive],
+    axis: usize,
+    split: f64,
+) -> usize {
+    let mut left = 0usize;
+    for i in 0..indices.len() {
+        if centroid_component(&primitives[indices[i]], axis) < split {
+            indices.swap(left, i);
+            left += 1;
+        }
+    }
+    left
+}
+
+/// Sort `indices` along `axis` and return the median offset (always a valid,
+/// non-empty split for slices of length >= 2). Used as a fallback when SAH
+/// cannot find a useful split (e.g. coincident centroids).
+fn median_split(indices: &mut [usize], primitives: &[TrianglePrimitive], axis: usize) -> usize {
+    indices.sort_by(|&a, &b| {
+        centroid_component(&primitives[a], axis)
+            .partial_cmp(&centroid_component(&primitives[b], axis))
+            .unwrap_or(Ordering::Equal)
+    });
+    indices.len() / 2
+}
+
 fn merge_bounds(min_a: Vec3, max_a: Vec3, min_b: Vec3, max_b: Vec3) -> (Vec3, Vec3) {
     let min = Vec3::new(
         min_a.x.min(min_b.x),
@@ -168,24 +255,85 @@ fn build_bvh_nodes(
         centroid_max.z - centroid_min.z,
     );
 
-    let mut axis = 0;
+    // Largest-extent axis, used as the SAH fallback when no good split exists.
+    let mut largest_axis = 0;
     if extent.y > extent.x {
-        axis = 1;
+        largest_axis = 1;
     }
-    if extent.z > if axis == 0 { extent.x } else { extent.y } {
-        axis = 2;
+    if extent.z > axis_value(extent, largest_axis) {
+        largest_axis = 2;
     }
 
-    indices[start..end].sort_by(|&a, &b| {
-        centroid_component(&primitives[a], axis)
-            .partial_cmp(&centroid_component(&primitives[b], axis))
-            .unwrap_or(Ordering::Equal)
-    });
+    // Binned Surface Area Heuristic: evaluate candidate split planes across all
+    // three axes and pick the one minimising expected traversal cost. This
+    // produces tighter, faster-to-traverse trees than a plain median split.
+    const NUM_BINS: usize = 12;
+    let mut best_cost = f64::INFINITY;
+    let mut best_axis = largest_axis;
+    let mut best_split = 0.0f64;
+    let mut found_split = false;
 
-    let mut mid = start + count / 2;
-    if mid == start || mid == end {
-        mid = start + count / 2;
+    for axis in 0..3 {
+        let axis_min = axis_value(centroid_min, axis);
+        let axis_extent = axis_value(extent, axis);
+        if axis_extent <= 0.0 {
+            continue;
+        }
+
+        let mut bins = [SahBin::empty(); NUM_BINS];
+        let scale = NUM_BINS as f64 / axis_extent;
+        for &idx in &indices[start..end] {
+            let c = centroid_component(&primitives[idx], axis);
+            let mut bin = ((c - axis_min) * scale) as usize;
+            if bin >= NUM_BINS {
+                bin = NUM_BINS - 1;
+            }
+            bins[bin].count += 1;
+            bins[bin].expand(primitives[idx].bounds_min, primitives[idx].bounds_max);
+        }
+
+        // Prefix sweep: bounds/count of everything left of each split plane.
+        let mut left_area = [0.0f64; NUM_BINS - 1];
+        let mut left_count = [0usize; NUM_BINS - 1];
+        let mut acc = SahBin::empty();
+        for i in 0..(NUM_BINS - 1) {
+            acc.merge(&bins[i]);
+            left_area[i] = acc.area();
+            left_count[i] = acc.count;
+        }
+
+        // Suffix sweep: combine with the right side to score each plane.
+        let mut acc_right = SahBin::empty();
+        for i in (0..(NUM_BINS - 1)).rev() {
+            acc_right.merge(&bins[i + 1]);
+            if left_count[i] == 0 || acc_right.count == 0 {
+                continue;
+            }
+            let cost =
+                left_area[i] * left_count[i] as f64 + acc_right.area() * acc_right.count as f64;
+            if cost < best_cost {
+                best_cost = cost;
+                best_axis = axis;
+                best_split = axis_min + (i as f64 + 1.0) * (axis_extent / NUM_BINS as f64);
+                found_split = true;
+            }
+        }
     }
+
+    let left_count = {
+        let slice = &mut indices[start..end];
+        let mut lc = if found_split {
+            partition_indices(slice, primitives, best_axis, best_split)
+        } else {
+            median_split(slice, primitives, best_axis)
+        };
+        // Guard against a degenerate partition (all primitives on one side).
+        if lc == 0 || lc == count {
+            lc = median_split(slice, primitives, best_axis);
+        }
+        lc
+    };
+    let mid = start + left_count;
 
     let (left_child, left_min, left_max) =
         build_bvh_nodes(primitives, indices, start, mid, nodes, output_triangles);

--- a/src/material.rs
+++ b/src/material.rs
@@ -37,6 +37,15 @@ impl Material {
         }
     }
 
+    pub fn new_dielectric(color: Vec3, roughness: f64) -> Self {
+        Material {
+            color,
+            roughness,
+            material_type: MaterialType::Dielectric,
+            metallic: 0.0,
+        }
+    }
+
     pub fn new_mixed(color: Vec3, roughness: f64, metallic: f64) -> Self {
         let material_type = if metallic > 0.5 {
             MaterialType::Metallic

--- a/src/shaders/raytracer.wgsl
+++ b/src/shaders/raytracer.wgsl
@@ -73,10 +73,24 @@ var environment_sampler: sampler;
 const BVH_STACK_SIZE: u32 = 64u;
 const LARGE_DISTANCE: f32 = 1e30;
 
+// PCG3D: a high-quality integer hash (Mark Jarzynski & Marc Olano, JCGT 2020).
+// Replaces the old fract(sin(...)) hash, which had poor decorrelation and
+// relied on sin() precision that varies between GPUs.
+fn pcg3d(v_in: vec3<u32>) -> vec3<u32> {
+    var v = v_in * 1664525u + 1013904223u;
+    v.x = v.x + v.y * v.z;
+    v.y = v.y + v.z * v.x;
+    v.z = v.z + v.x * v.y;
+    v = v ^ (v >> vec3<u32>(16u));
+    v.x = v.x + v.y * v.z;
+    v.y = v.y + v.z * v.x;
+    v.z = v.z + v.x * v.y;
+    return v;
+}
+
 fn hash_float3(value: vec3<u32>) -> f32 {
-    let value_f = vec3<f32>(f32(value.x), f32(value.y), f32(value.z));
-    let dot_product = dot(value_f, vec3<f32>(0.1031, 0.11369, 0.13787));
-    return fract(sin(dot_product) * 43758.5453);
+    // Map the top word of the PCG3D output to [0, 1).
+    return f32(pcg3d(value).x) * (1.0 / 4294967296.0);
 }
 
 fn random2(pixel: vec2<u32>, sample: u32, frame_seed: u32) -> vec2<f32> {
@@ -98,42 +112,60 @@ fn random_unit_vector(seed: vec3<u32>) -> vec3<f32> {
     return vec3<f32>(cos(theta) * r, sin(theta) * r, z);
 }
 
-fn random_in_hemisphere(normal: vec3<f32>, seed: vec3<u32>) -> vec3<f32> {
-    var dir = random_unit_vector(seed);
-    if (dot(dir, normal) < 0.0) {
-        dir = -dir;
-    }
-    return dir;
+fn random_pair(seed: vec3<u32>) -> vec2<f32> {
+    let r = pcg3d(seed);
+    return vec2<f32>(f32(r.x), f32(r.y)) * (1.0 / 4294967296.0);
 }
 
 fn reflect(incident: vec3<f32>, normal: vec3<f32>) -> vec3<f32> {
     return incident - 2.0 * dot(incident, normal) * normal;
 }
 
-// Sample a direction based on material type
-fn sample_material_direction(
+// Cosine-weighted hemisphere sampling around `normal`. The cosine term in the
+// diffuse rendering equation cancels the pdf (cos/PI), so paths sampled this way
+// need only weight throughput by the surface albedo.
+fn cosine_sample_hemisphere(normal: vec3<f32>, seed: vec3<u32>) -> vec3<f32> {
+    let xi = random_pair(seed);
+    let r = sqrt(xi.x);
+    let theta = 2.0 * PI * xi.y;
+    let x = r * cos(theta);
+    let y = r * sin(theta);
+    let z = sqrt(max(0.0, 1.0 - xi.x));
+
+    // Build an orthonormal basis around the normal.
+    let up = select(vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(1.0, 0.0, 0.0), abs(normal.y) > 0.999);
+    let tangent = normalize(cross(up, normal));
+    let bitangent = cross(normal, tangent);
+    return normalize(tangent * x + bitangent * y + normal * z);
+}
+
+// Choose an outgoing direction for the surface interaction. The specular and
+// diffuse lobes are selected stochastically with probability `metallic`; because
+// each lobe's BRDF weight is cancelled by its selection probability, the caller
+// updates throughput simply with *= albedo, keeping the path tracer energy
+// conserving (no ad-hoc loss factors).
+fn scatter_direction(
     incident_dir: vec3<f32>,
     normal: vec3<f32>,
     roughness: f32,
     metallic: f32,
     seed: vec3<u32>
 ) -> vec3<f32> {
-    // Perfect reflection for metallic
-    let reflected = reflect(incident_dir, normal);
-
-    // Diffuse scatter
-    let diffuse = random_in_hemisphere(normal, seed);
-
-    // Blend between diffuse and reflection based on metallic value
-    let dir = mix(diffuse, reflected, metallic);
-
-    // Add roughness by perturbing the direction slightly
-    if (roughness > 0.01) {
-        let perturb = random_unit_vector(seed + vec3<u32>(7u, 11u, 13u)) * roughness;
-        return normalize(dir + perturb);
+    let select_specular = random_float(seed + vec3<u32>(101u, 53u, 29u)) < metallic;
+    if (select_specular) {
+        let reflected = reflect(incident_dir, normal);
+        var dir = reflected;
+        if (roughness > 0.01) {
+            let perturb = random_unit_vector(seed + vec3<u32>(7u, 11u, 13u)) * roughness;
+            dir = normalize(reflected + perturb);
+        }
+        // Keep glossy reflections in the upper hemisphere.
+        if (dot(dir, normal) < 0.0) {
+            dir = reflected;
+        }
+        return dir;
     }
-
-    return normalize(dir);
+    return cosine_sample_hemisphere(normal, seed);
 }
 
 fn sky_color(ray_dir: vec3<f32>) -> vec3<f32> {
@@ -372,37 +404,6 @@ fn trace_ray(origin: vec3<f32>, dir: vec3<f32>) -> HitInfo {
     return closest_hit;
 }
 
-fn evaluate_environment(
-    normal: vec3<f32>,
-    albedo: vec3<f32>,
-    view_dir: vec3<f32>,
-    roughness: f32,
-    metallic: f32
-) -> vec3<f32> {
-    let n = normalize(normal);
-
-    // Approximate diffuse contribution by sampling the environment along the surface normal.
-    let env_diffuse = sky_color(n);
-    let diffuse = albedo * env_diffuse * (1.0 - metallic) * (1.0 / PI);
-
-    // Approximate specular contribution by sampling the environment in the reflection direction.
-    let reflection_dir = reflect(-view_dir, n);
-    let raw_specular = sky_color(reflection_dir);
-
-    // Rough surfaces see a blurrier environment; approximate by blending with the diffuse sample.
-    let reflectivity = pow(1.0 - roughness, 4.0);
-    let env_specular = mix(env_diffuse, raw_specular, reflectivity);
-
-    // Fresnel term (Schlick approximation) to mix specular color.
-    let f0 = mix(vec3<f32>(0.04), albedo, metallic);
-    let cos_theta = clamp(dot(normalize(view_dir), n), 0.0, 1.0);
-    let fresnel = f0 + (vec3<f32>(1.0) - f0) * pow(1.0 - cos_theta, 5.0);
-
-    let specular = env_specular * fresnel * reflectivity;
-
-    return diffuse + specular;
-}
-
 @compute @workgroup_size(8, 8)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (global_id.x >= scene.resolution.x || global_id.y >= scene.resolution.y) {
@@ -437,6 +438,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         for (var bounce: u32 = 0u; bounce < max_bounces; bounce = bounce + 1u) {
             let hit = trace_ray(ray_origin, ray_dir);
             if (!hit.hit) {
+                // Ray escaped to the environment: collect sky radiance. This is
+                // the only place sky light enters the path, so each surface is
+                // lit exactly once (no per-bounce double counting).
                 radiance = radiance + throughput * sky_color(ray_dir);
                 path_active = false;
                 break;
@@ -444,29 +448,25 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
             let hit_pos = ray_origin + ray_dir * hit.dist;
 
-            // Compute view direction for specular
-            let view_dir = normalize(-ray_dir);
-
-            // Evaluate direct lighting (includes diffuse and specular)
-            let direct = evaluate_environment(hit.normal, hit.color, view_dir, hit.roughness, hit.metallic);
-            radiance = radiance + throughput * direct;
-
-            let bounce_albedo = mix(hit.color, vec3<f32>(1.0), hit.metallic);
-            let scatter_loss = mix(0.85, 0.98, hit.metallic);
-            throughput = throughput * bounce_albedo * scatter_loss;
-
             let bounce_seed = vec3<u32>(
                 pixel_coords.x + 17u * bounce + 13u * sample,
                 pixel_coords.y + 31u * bounce + 7u * sample,
                 sample * max_bounces + bounce + frame_seed * 1000u,
             );
-            ray_origin = hit_pos + hit.normal * 1e-3;
 
-            // Use material-aware direction sampling
-            ray_dir = sample_material_direction(ray_dir, hit.normal, hit.roughness, hit.metallic, bounce_seed);
+            // Surfaces are not emitters: lighting is gathered by tracing the
+            // scattered ray. With cosine-weighted diffuse sampling and stochastic
+            // lobe selection, the throughput update is just *= albedo (the BRDF
+            // weights and pdfs cancel), so the estimator stays energy conserving.
+            throughput = throughput * hit.color;
+
+            ray_origin = hit_pos + hit.normal * 1e-3;
+            ray_dir = scatter_direction(ray_dir, hit.normal, hit.roughness, hit.metallic, bounce_seed);
         }
 
-        // If path is still active after max bounces, add environment contribution
+        // Paths that exhaust the bounce budget approximate their remaining
+        // contribution with the environment along the last scattered direction.
+        // This is a bounded approximation, not a re-add of already-counted light.
         if (path_active) {
             radiance = radiance + throughput * sky_color(ray_dir);
         }

--- a/src/shaders/raytracer.wgsl
+++ b/src/shaders/raytracer.wgsl
@@ -177,10 +177,32 @@ fn scatter_direction(
 
         let xi = random_float(seed + vec3<u32>(211u, 97u, 41u));
         // Total internal reflection, or a Fresnel-weighted reflection event.
-        if (eta * sin_theta > 1.0 || reflectance > xi) {
-            return reflect(unit_in, oriented_n);
+        let reflecting = eta * sin_theta > 1.0 || reflectance > xi;
+
+        if (reflecting) {
+            let reflected = reflect(unit_in, oriented_n);
+            // Frosted glass: perturb the reflection, keeping it above the surface.
+            if (roughness > 0.01) {
+                let perturb = random_unit_vector(seed + vec3<u32>(7u, 11u, 13u)) * roughness;
+                let rough_dir = normalize(reflected + perturb);
+                if (dot(rough_dir, oriented_n) > 0.0) {
+                    return rough_dir;
+                }
+            }
+            return reflected;
         }
-        return refract(unit_in, oriented_n, eta);
+
+        let refracted = refract(unit_in, oriented_n, eta);
+        // Frosted glass: perturb the refraction, keeping it on the transmitted
+        // side (the opposite hemisphere from the oriented normal).
+        if (roughness > 0.01) {
+            let perturb = random_unit_vector(seed + vec3<u32>(23u, 29u, 31u)) * roughness;
+            let rough_dir = normalize(refracted + perturb);
+            if (dot(rough_dir, oriented_n) < 0.0) {
+                return rough_dir;
+            }
+        }
+        return refracted;
     }
 
     let select_specular = random_float(seed + vec3<u32>(101u, 53u, 29u)) < metallic;

--- a/src/shaders/raytracer.wgsl
+++ b/src/shaders/raytracer.wgsl
@@ -139,18 +139,50 @@ fn cosine_sample_hemisphere(normal: vec3<f32>, seed: vec3<u32>) -> vec3<f32> {
     return normalize(tangent * x + bitangent * y + normal * z);
 }
 
-// Choose an outgoing direction for the surface interaction. The specular and
-// diffuse lobes are selected stochastically with probability `metallic`; because
-// each lobe's BRDF weight is cancelled by its selection probability, the caller
-// updates throughput simply with *= albedo, keeping the path tracer energy
-// conserving (no ad-hoc loss factors).
+// Material type tags (must match gpu_scene.rs / sphere_to_gpu): 0 diffuse,
+// 1 metallic, 2 dielectric (glass).
+const MATERIAL_DIELECTRIC: f32 = 1.5; // threshold: material_type > this == glass
+const GLASS_IOR: f32 = 1.5;
+
+// Choose an outgoing direction for the surface interaction.
+// - Dielectric (glass): stochastically reflect or refract using the Fresnel
+//   (Schlick) reflectance, handling total internal reflection.
+// - Otherwise: specular and diffuse lobes are selected stochastically with
+//   probability `metallic`; because each lobe's BRDF weight is cancelled by its
+//   selection probability, the caller updates throughput simply with *= albedo,
+//   keeping the path tracer energy conserving (no ad-hoc loss factors).
 fn scatter_direction(
     incident_dir: vec3<f32>,
     normal: vec3<f32>,
     roughness: f32,
     metallic: f32,
+    material_type: f32,
     seed: vec3<u32>
 ) -> vec3<f32> {
+    if (material_type > MATERIAL_DIELECTRIC) {
+        let unit_in = normalize(incident_dir);
+        // Outward normal points away from the surface; orient it against the
+        // incoming ray and pick the index ratio for entering vs exiting glass.
+        let front_face = dot(unit_in, normal) < 0.0;
+        let oriented_n = select(-normal, normal, front_face);
+        let eta = select(GLASS_IOR, 1.0 / GLASS_IOR, front_face);
+
+        let cos_theta = min(dot(-unit_in, oriented_n), 1.0);
+        let sin_theta = sqrt(max(0.0, 1.0 - cos_theta * cos_theta));
+
+        // Schlick approximation of the Fresnel reflectance.
+        let r0_root = (1.0 - eta) / (1.0 + eta);
+        let r0 = r0_root * r0_root;
+        let reflectance = r0 + (1.0 - r0) * pow(1.0 - cos_theta, 5.0);
+
+        let xi = random_float(seed + vec3<u32>(211u, 97u, 41u));
+        // Total internal reflection, or a Fresnel-weighted reflection event.
+        if (eta * sin_theta > 1.0 || reflectance > xi) {
+            return reflect(unit_in, oriented_n);
+        }
+        return refract(unit_in, oriented_n, eta);
+    }
+
     let select_specular = random_float(seed + vec3<u32>(101u, 53u, 29u)) < metallic;
     if (select_specular) {
         let reflected = reflect(incident_dir, normal);
@@ -404,6 +436,20 @@ fn trace_ray(origin: vec3<f32>, dir: vec3<f32>) -> HitInfo {
     return closest_hit;
 }
 
+// Clamp the luminance of an indirect contribution to suppress fireflies: rare
+// very bright paths (e.g. a glossy/refractive bounce that catches the sun)
+// otherwise leave speckles that persist through temporal accumulation. Applied
+// only to bounced light, never to the directly-visible background.
+const FIREFLY_MAX_LUMINANCE: f32 = 8.0;
+
+fn clamp_firefly(contribution: vec3<f32>) -> vec3<f32> {
+    let luminance = dot(contribution, vec3<f32>(0.2126, 0.7152, 0.0722));
+    if (luminance > FIREFLY_MAX_LUMINANCE) {
+        return contribution * (FIREFLY_MAX_LUMINANCE / luminance);
+    }
+    return contribution;
+}
+
 @compute @workgroup_size(8, 8)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if (global_id.x >= scene.resolution.x || global_id.y >= scene.resolution.y) {
@@ -440,8 +486,15 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
             if (!hit.hit) {
                 // Ray escaped to the environment: collect sky radiance. This is
                 // the only place sky light enters the path, so each surface is
-                // lit exactly once (no per-bounce double counting).
-                radiance = radiance + throughput * sky_color(ray_dir);
+                // lit exactly once (no per-bounce double counting). The primary
+                // ray (bounce 0) is the directly-visible background and is kept
+                // unclamped; bounced contributions are firefly-clamped.
+                let contribution = throughput * sky_color(ray_dir);
+                if (bounce == 0u) {
+                    radiance = radiance + contribution;
+                } else {
+                    radiance = radiance + clamp_firefly(contribution);
+                }
                 path_active = false;
                 break;
             }
@@ -460,15 +513,18 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
             // weights and pdfs cancel), so the estimator stays energy conserving.
             throughput = throughput * hit.color;
 
-            ray_origin = hit_pos + hit.normal * 1e-3;
-            ray_dir = scatter_direction(ray_dir, hit.normal, hit.roughness, hit.metallic, bounce_seed);
+            ray_dir = scatter_direction(ray_dir, hit.normal, hit.roughness, hit.metallic, hit.material_type, bounce_seed);
+            // Offset along whichever side of the surface the new ray leaves on,
+            // so transmitted (refracted) rays are pushed inside, not back out.
+            let offset_normal = select(-hit.normal, hit.normal, dot(ray_dir, hit.normal) >= 0.0);
+            ray_origin = hit_pos + offset_normal * 1e-3;
         }
 
         // Paths that exhaust the bounce budget approximate their remaining
         // contribution with the environment along the last scattered direction.
         // This is a bounded approximation, not a re-add of already-counted light.
         if (path_active) {
-            radiance = radiance + throughput * sky_color(ray_dir);
+            radiance = radiance + clamp_firefly(throughput * sky_color(ray_dir));
         }
 
         color_accum = color_accum + radiance;


### PR DESCRIPTION
## Summary

Renderer correctness and quality improvements.

### 1. Better RNG hash (`raytracer.wgsl`)
Replaced the `fract(sin(...)) * 43758.5453` hash with **PCG3D**, an integer hash. The old hash had poor decorrelation and relied on `sin()` precision that varies between GPUs, so the demo could look different/banded across machines. Drop-in via the same `hash_float3` signature.

### 2. SAH BVH (`gpu_scene.rs`)
Replaced the median centroid split with a **binned Surface Area Heuristic** (12 bins across all 3 axes), with a median fallback for degenerate cases. Tighter, faster-to-traverse trees. Removed a dead no-op.

### 3. Energy-conserving path tracing (`raytracer.wgsl`)
The previous shading **double-counted** environment light (a full IBL estimate added at every hit, plus the path kept bouncing and adding sky again). Rewritten as a proper path tracer:
- Sky radiance collected **only when a ray escapes** → each surface lit exactly once.
- Dropped the arbitrary `scatter_loss` energy fudge; throughput update is now `*= albedo`.
- **Cosine-weighted** hemisphere sampling (was uniform, mismatched with the ÷π).
- **Stochastic diffuse/specular lobe selection** weighted by `metallic`.
- Removed dead `evaluate_environment`, `sample_material_direction`, `random_in_hemisphere`.

### 4. Dielectric / glass material (`raytracer.wgsl`, `live_raytracer.rs`)
`material_type == 2.0` was plumbed through but never shaded. Now `scatter_direction` handles dielectrics with **Fresnel (Schlick) reflect/refract** and total internal reflection, and the next ray origin is offset along the outgoing side so refracted rays are pushed inside the surface. Added a `glass` flag to `SceneObject` with a **"Glass (refractive)" UI checkbox**; the default blue sphere is now a clear glass sphere to showcase it.

### 5. Firefly clamping (`raytracer.wgsl`)
Clamps the luminance of **indirect** sky contributions to suppress speckles that otherwise persist through temporal accumulation (e.g. a glossy/refractive bounce catching the sun). The directly-visible background is left unclamped.

**Behavioral note:** in realtime mode (1 spp, 2 bounces) the first frame is noisier than the old smooth-but-wrong look, but it's now physically correct and converges cleanly via the existing temporal accumulation when the camera is still.

## Verification
- `cargo build` ✅
- `cargo test --workspace` ✅ (11 passed)
- `naga` validates `raytracer.wgsl` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)